### PR TITLE
Add missing version to tarballs/zipballs

### DIFF
--- a/.circleci/generate_artifacts.sh
+++ b/.circleci/generate_artifacts.sh
@@ -12,8 +12,8 @@ export VERSION=$(git describe --tags --always --dirty)
 for item in release-builds/DDEV*; do
 	pushd $item
 	filebase=$(basename $item)
-	tar -czf $ARTIFACTS/${filebase}.tar.gz .
-	zip $ARTIFACTS/${filebase}.zip *
+	tar -czf $ARTIFACTS/${filebase}.$VERSION.tar.gz .
+	zip $ARTIFACTS/${filebase}.$VERSION.zip *
 	popd
 done
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

I noticed that I had failed to include the version (from git) in the tarball and zipball package names.

## How this PR Solves The Problem:

It adds them.

## Manual Testing Instructions:

Look at the tarballs now in Circle, for example https://circleci.com/gh/drud/ddev-ui/30#artifacts/containers/0

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

