### PR TITLE
Do brew update first to avoid ruby complaint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ stages:
       - run:
           name: VM setup
           command: |
+            brew update  # added for https://discuss.circleci.com/t/homebrew-must-be-run-under-ruby-2-3-runtimeerror/17232/5
             brew cask install xquartz  # A dependency of wine
             brew install node wine
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

Our builds started failing with [/usr/local/Homebrew/Library/Homebrew/brew.rb:12:in `<main>': Homebrew must be run under Ruby 2.3](https://circleci.com/gh/drud/ddev-ui/71).

This seems to be addressed in https://discuss.circleci.com/t/homebrew-must-be-run-under-ruby-2-3-runtimeerror/17232

So we'll try the brew update as a separate step.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

