### PR TITLE
[AT] - updated ddev-shell library and markup calling it to accept an …

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -21,9 +21,9 @@ function fetchState() {
     });
 }
 
-function getDescribe(siteName) {
+function getDescribe(siteName, errorCallback) {
     var promise = new Promise(function(resolve, reject) {
-        ddevShell.describe(siteName).then(function(data){
+        ddevShell.describe(siteName, errorCallback).then(function(data){
             resolve(data);
         })
     });
@@ -147,15 +147,15 @@ function bindButtons(){
     });
     $(document).on('click', '.startbtn', function(){
         console.log('starting');
-        ddevShell.start($(this).closest('.column').data('path'), function(data){console.log(data)});
+        ddevShell.start($(this).closest('.column').data('path'), function(data){console.log(data)}, function(error){console.log(error)});
     });
     $(document).on('click', '.stopbtn', function(){
         console.log('stopping');
-        ddevShell.stop($(this).closest('.column').data('path'), function(data){console.log(data)});
+        ddevShell.stop($(this).closest('.column').data('path'), function(data){console.log(data)}, function(error){console.log(error)});
     });
     $(document).on('click', '.restartbtn', function(){
         console.log('restarting');
-        ddevShell.restart($(this).closest('.column').data('path'), function(data){console.log(data)});
+        ddevShell.restart($(this).closest('.column').data('path'), function(data){console.log(data)}, function(error){console.log(error)});
     });
     $(document).on('click', '.removebtn', function(){
         displayPrompt();

--- a/test/ddev-shell-fixtures.js
+++ b/test/ddev-shell-fixtures.js
@@ -1,0 +1,41 @@
+const validListOutput = `
+1 local site found.
+NAME        TYPE     LOCATION            URL                           STATUS          
+fakedrupal  drupal7  ~/Downloads/drupal  http://fakedrupal.ddev.local  running
+fakewordpress  wordpress  ~/Downloads/wordpress  http://wordpress.ddev.local  running
+
+DDEV ROUTER STATUS: running
+        
+`;
+
+const expectedSitesArray = [
+    {
+        name: 'fakedrupal',
+        type: 'drupal7',
+        path: '~/Downloads/drupal',
+        url: 'http://fakedrupal.ddev.local',
+        state: 'running'
+    }, {
+        name: 'fakewordpress',
+        type: 'wordpress',
+        path: '~/Downloads/wordpress',
+        url: 'http://wordpress.ddev.local',
+        state: 'running'
+    }
+];
+
+const validStartOutput = "Successfully started drupaltest";
+const invalidStartOutput = "Unable to start drupaltest";
+const validStopOutput = "Application has been stopped.";
+const invalidStopOutput = "Unable to stop drupaltest";
+const validRestartOutput = "Successfully restarted drupaltest";
+const invalidRestartOutput = "Unable to restart drupaltest";
+
+module.exports.validListOutput = validListOutput;
+module.exports.expectedSitesArray = expectedSitesArray;
+module.exports.validStartOutput = validStartOutput;
+module.exports.invalidStartOutput = invalidStartOutput;
+module.exports.validStopOutput = validStopOutput;
+module.exports.invalidStopOutput = invalidStopOutput;
+module.exports.validRestartOutput = validRestartOutput;
+module.exports.invalidRestartOutput = invalidRestartOutput;


### PR DESCRIPTION
…error callback, added test coverage for start, stop, and restart.

## The Problem/Issue/Bug:
functionality requested in #13 has been finished for a while, but the testing required for acceptance was not complete.

## How this PR Solves The Problem:
code was changed to add an error callback to enable error handling, and new tests to confirm success and failure of ddev start/stop/restart were added.

## Manual Testing Instructions:
run npm test

## Automated Testing Overview:
Tests confirming success and failure of ddev start/stop/restart and related fixtures were added into /test/ddev-shell-fixtures.js and /test/ddev-shell-tests.js

## Related Issue Link(s):
#13 

