### PR TITLE
More minor readme update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,9 @@ DDEV UI has been tested on macOS, Win7/8/10, Ubuntu 16.04+ and Fedora 25+. The f
 * windows: `make windows`
 * linux: `make linux`
 
-While developing and testing locally, you may wish to skip building the full binary by
+While developing and testing casually locally (not for formal reviews), you may wish to skip building the full binary by running `npm install && npm start` in the main ddev-ui directory.
 
-* Globally installing electron (one-time) with `npm install -g electron`
-* then start ddev-ui with `npm install && electron .` in the main ddev-ui directory.
-
-This will launch the electron app without requiring building disk images and closing/reopening the binary.
+This will launch the ddev-ui electron app without requiring building disk images and closing/reopening the binary. 
 
 ## Initial Roadmap
 The planned roadmap can be found at 


### PR DESCRIPTION
## The Problem/Issue/Bug:

After https://github.com/drud/ddev-ui/pull/68 went in we discovered you don't need a global electron at all, a simple `npm start` does the job. 

This is a tiny README update.

## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

