### PR TITLE
setup the ability to choose whether we run ddev config #86

### DIFF
--- a/src/renderer/components/CreateProjectWizard.jsx
+++ b/src/renderer/components/CreateProjectWizard.jsx
@@ -228,9 +228,12 @@ export function addCMSFromExisting(name, targetPath, docroot = '', history = {})
   showLoadingScreen(true);
   validateExistingFilesInputs(name, targetPath, docroot)
     .then(() => checkIfExistingConfig(targetPath))
-    .then(() => {
-      showLoadingScreen(true, 'Configuring Project');
-      return configureSite(name, targetPath, docroot);
+    .then(shouldConfig => {
+      if (shouldConfig) {
+        showLoadingScreen(true, 'Configuring Project');
+        return configureSite(name, targetPath, docroot);
+      }
+      return Promise.resolve(true);
     })
     .then(() => {
       showLoadingScreen(true, 'Updating Hosts File');

--- a/src/renderer/modules/helpers.js
+++ b/src/renderer/modules/helpers.js
@@ -8,15 +8,12 @@ export function checkIfExistingConfig(path) {
   const promise = new Promise((resolve, reject) => {
     try {
       config(path, 'validName', 'totally invalid docroot that does not exist', null, messages => {
+        console.log(messages);
         if (messages.includes('existing configuration')) {
           const proceed = window.confirm(
-            `An existing DDEV configuration was found in ${path}. By proceeding, the existing configuration will be updated and replaced.`
+            `An existing DDEV config was found! \n\nClick Cancel to use the existing or OK to generate a new one.`
           );
-          if (proceed) {
-            resolve(true);
-          } else {
-            reject(new Error('User Canceled'));
-          }
+          resolve(proceed);
         } else {
           resolve(false);
         }


### PR DESCRIPTION
## The Problem/Issue/Bug:
#86 

## How this PR Solves The Problem:
Adds verbiage in the confirmation window and logic to handle if the user wants to use the existing config or generate a new one. 

## Manual Testing Instructions:
Download - https://397-99947022-gh.circle-artifacts.com/0/artifacts/DDEV%20UI-0.4.0-alpha.1.dmg
Add an existing install with on old or altered config.
  1. Choose cancel and see that it stays untouched.
  2. Remove Project
  3. Add it again, but choose ok to generate a new config, and confirm it get's updated.


