### PR TITLE
add a check for d7 being installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "font-awesome": "4.7.x",
     "jquery": "3.3.x",
     "lodash": "4.17.x",
+    "node-fetch": "^2.2.0",
     "popper.js": "1.14.x",
     "prop-types": "15.x",
     "react": "16.x",

--- a/src/renderer/components/ProjectHeader.jsx
+++ b/src/renderer/components/ProjectHeader.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import electron from 'electron';
+import fetch from 'node-fetch';
 
 import ProjectTypeIcon from './ProjectTypeIcon';
 import ProjectStatusIcon from './ProjectStatusIcon';
@@ -109,7 +110,12 @@ class ProjectHeader extends React.PureComponent {
                   className="open-site"
                   onClick={e => {
                     e.preventDefault();
-                    electron.shell.openExternal(this.props.httpurl);
+                    fetch(this.props.httpurl).then(res => {
+                      if (res.statusText.includes('Service unavailable')) {
+                        return electron.shell.openExternal(`${this.props.httpurl}/install.php`);
+                      }
+                      return electron.shell.openExternal(this.props.httpurl);
+                    });
                   }}
                 >
                   {this.props.name}
@@ -169,21 +175,26 @@ class ProjectHeader extends React.PureComponent {
               className="btn btn-outline-secondary"
               onClick={e => {
                 e.preventDefault();
-                electron.shell.openExternal(this.props.httpurl);
+                fetch(this.props.httpurl).then(res => {
+                  if (res.statusText.includes('Service unavailable')) {
+                    return electron.shell.openExternal(`${this.props.httpurl}/install.php`);
+                  }
+                  return electron.shell.openExternal(this.props.httpurl);
+                });
               }}
             >
               View Site
             </button>
-            <button
+            {/* <button
               type="button"
               className="btn btn-outline-secondary"
               onClick={e => {
                 e.preventDefault();
-                electron.shell.openExternal(this.props.httpurl);
+                electron.shell.openExternal(this.props.phpmyadmin_url);
               }}
             >
-              Site Admin
-            </button>
+              phpMyAdmin
+            </button> */}
           </div>
         </div>
       </header>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7209,6 +7209,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
+
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"


### PR DESCRIPTION
## The Problem/Issue/Bug:
D7 on a new install, needs to go through the install steps, but the "View Site " Link seems broken until that's done.

## How this PR Solves The Problem:
It fetches the project URL for the status and alters the Button URL.

## Manual Testing Instructions:
Start a new D7 Site and click "View Site" after DDEv is done setting up the install. It should take you to `/install.php`

## Related Issue Link(s):
https://github.com/drud/ddev-ui/issues/124

