### PR TITLE
disable createProject steps as buttons, enabled step highlighting #134

### DIFF
--- a/src/renderer/components/CreateProjectWizard.jsx
+++ b/src/renderer/components/CreateProjectWizard.jsx
@@ -455,7 +455,7 @@ class CreateProjectWizard extends React.Component {
           )}
         </form>
         {/* Steps */}
-        <WizardSteps />
+        <WizardSteps activeStep={this.state.step} />
       </div>
     );
   }

--- a/src/renderer/components/CreateProjectWizard/WizardSteps.jsx
+++ b/src/renderer/components/CreateProjectWizard/WizardSteps.jsx
@@ -7,23 +7,35 @@ class WizardSteps extends React.PureComponent {
         <div className="stepwizard-row form-row h-100 btn-breadcrumb align-items-center setup-panel clearfix">
           {/* Step 1 */}
           <div className="stepwizard-step col-4">
-            <a href="#step-1" className="btn btn-outline-primary btn-circle">
+            <span
+              className={`border ${
+                this.props.activeStep === '1' ? 'border-primary' : 'border-secondary'
+              } btn-circle`}
+            >
               1
-            </a>
+            </span>
             <span>Project Setup</span>
           </div>
           {/* Step 2 */}
           <div className="stepwizard-step col-4">
-            <a href="#step-2" className="btn btn-outline-secondary btn-circle" disabled>
+            <span
+              className={`border ${
+                this.props.activeStep === '2' ? 'border-primary' : 'border-secondary'
+              } btn-circle`}
+            >
               2
-            </a>
+            </span>
             <span>Container Settings</span>
           </div>
           {/* Step 3 */}
           <div className="stepwizard-step col-4">
-            <a href="#step-3" className="btn btn-outline-secondary btn-circle" disabled>
+            <span
+              className={`border ${
+                this.props.activeStep === '3' ? 'border-primary' : 'border-secondary'
+              } btn-circle`}
+            >
               3
-            </a>
+            </span>
             <span>Platform Setup</span>
           </div>
         </div>


### PR DESCRIPTION
## The Problem/Issue/Bug:
#134 

## How this PR Solves The Problem:
It removes the elements as buttons and makes them spans. It also adds state highlighting based on the active step.

## Manual Testing Instructions:
Download App - (https://418-99947022-gh.circle-artifacts.com/0/artifacts/DDEV%20UI-0.4.1-alpha.dmg)
1. Create a new project and try and click on the number buttons. You should NOT be able to.
2. As you go through creating a project, the current step should be highlighted in blue, and the rest in gray.

## Release/Deployment notes:
Bug Fix

