### PR TITLE
Add title to HTML elements and replace the site list with createProject

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -51,6 +51,9 @@ const sendStatusToWindow = text => {
 const createMainWindow = () => {
   const window = new BrowserWindow({
     titleBarStyle: 'hidden',
+    minWidth: 800,
+    minHeight: 400,
+    zoomFactor: 0.8,
   });
 
   if (isDevelopment) {

--- a/src/renderer/components/Dashboard.jsx
+++ b/src/renderer/components/Dashboard.jsx
@@ -66,9 +66,9 @@ class Dashboard extends React.Component {
   updateRouterStatus = projects => {
     let routerStatusText = 'Not Running - No Running DDEV Applications.';
     const validRouterStates = ['starting', 'healthy'];
-    const routerStatus = _.isSet(Object.values(projects)[0].router_status)
+    const routerStatus = _.isObject(projects)
       ? Object.values(projects)[0].router_status
-      : -1;
+      : 'not-running';
 
     routerStatusText =
       validRouterStates.indexOf(routerStatus) !== -1
@@ -162,17 +162,19 @@ class Dashboard extends React.Component {
         </ErrorBoundary>
         <section className="app-container container-fluid">
           <div className="row h-100">
-            <ErrorBoundary onError={this.errorCapture}>
-              <Sidebar projects={this.state.projects} />
-            </ErrorBoundary>
-            <ErrorBoundary onError={this.errorCapture}>
-              <main className="content h-100 col-md-8">
-                <Status />
-                <Alpha />
-                <Alerts errorRemove={this.errorRemove} errors={this.state.errors} />
-                <ViewRouter projects={this.state.projects} />
-              </main>
-            </ErrorBoundary>
+            <Sidebar
+              className="projectSidebar col col-sm-5 col-md-4 p-0"
+              projects={this.state.projects}
+            />
+            <main className="content col col-sm-7 col-md-8">
+              <Status />
+              <Alerts errors={this.state.errors} />
+              <ViewRouter
+                addError={this.addError}
+                projects={this.state.projects}
+                errors={this.state.errors}
+              />
+            </main>
           </div>
         </section>
         <ErrorBoundary onError={this.errorCapture}>

--- a/src/renderer/components/ProjectActions.jsx
+++ b/src/renderer/components/ProjectActions.jsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import electron from 'electron';
+
+import { showLoadingScreen, showErrorScreen } from '../modules/helpers';
+import { start, restart, stop, remove } from '../modules/ddev-shell';
+
+class ProjectActions extends React.PureComponent {
+  processStart = e => {
+    e.preventDefault();
+    console.log('starting');
+    showLoadingScreen(true, 'Starting Project');
+    start(
+      $(e.target)
+        .closest('.actions')
+        .data('path'),
+      data => {
+        const res = data.toString();
+        if (res.includes('Process Exited')) {
+          showLoadingScreen(false);
+        } else {
+          showLoadingScreen(true, res);
+        }
+      },
+      err => {
+        console.error(err);
+        showErrorScreen(true, err.toString());
+      }
+    );
+  };
+
+  processRestart = e => {
+    e.preventDefault();
+    console.log('restarting');
+    showLoadingScreen(true, 'Restarting Project');
+    restart(
+      $(e.target)
+        .closest('.actions')
+        .data('path'),
+      data => {
+        const res = data.toString();
+        if (res.includes('Process Exited')) {
+          showLoadingScreen(false);
+        } else {
+          showLoadingScreen(true, res);
+        }
+      },
+      err => {
+        console.error(err);
+        showErrorScreen(true, err.toString());
+      }
+    );
+  };
+
+  processStop = e => {
+    e.preventDefault();
+    console.log('stopping');
+    showLoadingScreen(true, 'Stopping Project');
+    stop(
+      $(e.target)
+        .closest('.actions')
+        .data('path'),
+      data => {
+        const res = data.toString();
+        if (res.includes('Process Exited')) {
+          showLoadingScreen(false);
+        } else {
+          showLoadingScreen(true, res);
+        }
+      },
+      err => {
+        console.error(err);
+        showErrorScreen(true, err.toString());
+      }
+    );
+  };
+
+  processRemove = e => {
+    e.preventDefault();
+    console.log('removing');
+    showLoadingScreen(true, 'Removing Project');
+    remove(
+      $(e.target)
+        .closest('.actions')
+        .data('sitename'),
+      false,
+      data => {
+        const res = data.toString();
+        if (res.includes('Process Exited')) {
+          showLoadingScreen(false);
+          this.props.history.push('/');
+        } else {
+          showLoadingScreen(true, res);
+        }
+      },
+      err => {
+        console.error(err);
+        showErrorScreen(true, err.toString());
+      }
+    );
+  };
+
+  render() {
+    return (
+      <div className="actions" data-path={this.props.approot} data-sitename={this.props.name}>
+        {/* Browse Files */}
+        <a
+          title="Browse Files"
+          className="mx-1 text-secondary"
+          data-app-path={this.props.approot}
+          onClick={e => {
+            e.preventDefault();
+            electron.shell.showItemInFolder(this.props.approot);
+          }}
+          href="#!"
+        >
+          <i className="fa fa-folder-open-o" aria-hidden="true" />
+        </a>
+        {/* View */}
+        <a
+          title="View"
+          className="mx-1 text-secondary"
+          data-url={this.props.httpurl}
+          onClick={e => {
+            e.preventDefault();
+            electron.shell.openExternal(this.props.httpurl);
+          }}
+          href="#!"
+        >
+          <i className="fa fa-eye" aria-hidden="true" />
+        </a>
+        {/* Start */}
+        {this.props.status === 'stopped' && (
+          <a title="Start" className="mx-1 text-secondary" onClick={this.processStart} href="#!">
+            <i className="fa fa-play-circle" aria-hidden="true" />
+          </a>
+        )}
+        {/* Restart */}
+        {this.props.status !== 'stopped' && (
+          <a
+            title="Restart"
+            className="mx-1 text-secondary"
+            onClick={this.processRestart}
+            href="#!"
+          >
+            <i className="fa fa-retweet" aria-hidden="true" />
+          </a>
+        )}
+        {/* Stop */}
+        <a title="Stop" className="mx-1 text-secondary" onClick={this.processStop} href="#!">
+          <i className="fa fa-stop-circle-o" aria-hidden="true" />
+        </a>
+        {/* Remove */}
+        <a title="Remove" className="mx-1 text-danger" onClick={this.processRemove} href="#!">
+          <i className="fa fa-trash-o" aria-hidden="true" />
+        </a>
+      </div>
+    );
+  }
+}
+
+export default ProjectActions;

--- a/src/renderer/components/ProjectList.jsx
+++ b/src/renderer/components/ProjectList.jsx
@@ -51,7 +51,7 @@ class ProjectList extends React.PureComponent {
         }
         rows.push({
           id: (
-            <NavLink to={`/project/${project.name}/`}>
+            <NavLink title={project.name} to={`/project/${project.name}/`}>
               <i className={`fa fa-${platformIcon} fa-2 mr-2`} aria-hidden="true" /> {project.name}
             </NavLink>
           ),
@@ -59,6 +59,7 @@ class ProjectList extends React.PureComponent {
             <div className="actions" data-path={project.approot} data-sitename={project.name}>
               {/* Browse Files */}
               <a
+                title="Browse Files"
                 className="mx-1 text-secondary"
                 data-app-path={project.approot}
                 onClick={e => {
@@ -71,6 +72,7 @@ class ProjectList extends React.PureComponent {
               </a>
               {/* View */}
               <a
+                title="View"
                 className="mx-1 text-secondary"
                 data-url={project.httpurl}
                 onClick={e => {
@@ -83,22 +85,32 @@ class ProjectList extends React.PureComponent {
               </a>
               {/* Start */}
               {project.status === 'stopped' && (
-                <a className="mx-1 text-secondary" onClick={this.processStart} href="#!">
+                <a
+                  title="Start"
+                  className="mx-1 text-secondary"
+                  onClick={this.processStart}
+                  href="#!"
+                >
                   <i className="fa fa-play-circle" aria-hidden="true" />
                 </a>
               )}
               {/* Restart */}
               {project.status !== 'stopped' && (
-                <a className="mx-1 text-secondary" onClick={this.processRestart} href="#!">
+                <a
+                  title="Restart"
+                  className="mx-1 text-secondary"
+                  onClick={this.processRestart}
+                  href="#!"
+                >
                   <i className="fa fa-retweet" aria-hidden="true" />
                 </a>
               )}
               {/* Stop */}
-              <a className="mx-1 text-secondary" onClick={this.processStop} href="#!">
+              <a title="Stop" className="mx-1 text-secondary" onClick={this.processStop} href="#!">
                 <i className="fa fa-stop-circle-o" aria-hidden="true" />
               </a>
               {/* Remove */}
-              <a className="mx-1 text-danger" onClick={this.processRemove} href="#!">
+              <a title="Remove" className="mx-1 text-danger" onClick={this.processRemove} href="#!">
                 <i className="fa fa-trash-o" aria-hidden="true" />
               </a>
             </div>
@@ -215,7 +227,12 @@ class ProjectList extends React.PureComponent {
             this.state.rows.length !== 0 && (
               <ReactDataGrid
                 columns={[
-                  { key: 'id', name: 'ID', cellClass: '' },
+                  {
+                    key: 'id',
+                    name: 'ID',
+                    cellClass: '',
+                    // formatter: () => null,
+                  },
                   {
                     key: 'actions',
                     name: 'Actions',

--- a/src/renderer/components/Sidebar.jsx
+++ b/src/renderer/components/Sidebar.jsx
@@ -14,7 +14,7 @@ const settings = require(`${__static}/img/SettingsBlue.svg`); // eslint-disable-
 class Sidebar extends React.Component {
   render() {
     return (
-      <ListView className="projectSidebar h-md-100 col-md-4 p-0">
+      <ListView className={this.props.className}>
         <ListViewHeader
           padding="0.8rem 1rem 0.8rem 1rem"
           className="ListViewHeader align-items-center d-flex flex-row w-100"

--- a/src/renderer/components/ViewRouter.jsx
+++ b/src/renderer/components/ViewRouter.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 
-import ProjectList from './ProjectList';
 import ProjectDetail from './ProjectDetail';
 import CreateProjectWizard from './CreateProjectWizard';
 
@@ -24,7 +23,9 @@ class ViewRouter extends React.PureComponent {
             )}
           />
           <Route
-            render={routeProps => <ProjectList {...routeProps} projects={this.props.projects} />}
+            render={routeProps => (
+              <CreateProjectWizard {...routeProps} addError={this.props.addError} />
+            )}
           />
         </Switch>
       </HashRouter>

--- a/src/resources/scss/common/layout.scss
+++ b/src/resources/scss/common/layout.scss
@@ -6,7 +6,8 @@
 
 main.content,
 .projectSidebar {
-  overflow-y: scroll;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .selectable-text {
@@ -19,16 +20,7 @@ main.content,
 
 main.content {
   background-color: #fff;
-  position: relative;
-}
-
-main.content .fixed-bottom {
-  background: #f9f9f9;
-  @include media-breakpoint-up(md) {
-    // @include make-col-ready();
-    @include make-col(8);
-    @include make-col-offset(4);
-  }
+  // position: relative;
 }
 
 .no-gutters {

--- a/src/resources/scss/components/createProject.scss
+++ b/src/resources/scss/components/createProject.scss
@@ -122,9 +122,15 @@
 }
 
 .stepwizard {
-  width: 100%;
   min-height: 50px;
   bottom: 26px;
+  background: #f9f9f9;
+  @include make-col(7);
+  @include make-col-offset(5);
+  @include media-breakpoint-up(md) {
+    @include make-col(8);
+    @include make-col-offset(4);
+  }
 
   .stepwizard-step {
     text-align: center;


### PR DESCRIPTION
## The Problem/Issue/Bug:
#143 Resolve `object Obect`

## How this PR Solves The Problem:
After digging into this, I was able to fix it for the icons, but if you hover over the table cell it would still show. The issue is we are not showing data, but rendering a React component inside the table. We can get this to work, however this table just duplicates what can happen on the sidebar, and would be better used for the CreateProject.

## Manual Testing Instructions:
Download the build - (https://419-99947022-gh.circle-artifacts.com/0/artifacts/DDEV%20UI-0.4.1-alpha.dmg)
1. Open app and you should see the create project with the list on the side.
2. Everything should still function as normal.

## Related Issue Link(s):
#143 

## Release/Deployment notes:
Need to add project actions to the sidebar and adjust styling.

