### PR TITLE
update version number to v0.5.0-alpha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ include build-tools/makefile_components/base_test_python.mak
 
 .PHONY: build clean
 
-all: darwin linux windows
+# all: darwin linux windows
+all: darwin
 
 # Build requirements
 # - wine and mono must be available to build Windows on another platform (brew install wine mono )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ddev-ui",
   "description": "A GUI to complement the DDEV CLI",
-  "version": "v0.5.0-alpha",
+  "version": "v0.5.0",
   "main": "src/main/index.js",
   "homepage": "https://github.com/drud/ddev",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ddev-ui",
   "description": "A GUI to complement the DDEV CLI",
-  "version": "v0.4.2-alpha",
+  "version": "v0.5.0-alpha",
   "main": "src/main/index.js",
   "homepage": "https://github.com/drud/ddev",
   "author": {

--- a/src/renderer/components/CreateProjectWizard/ProjectSettings.jsx
+++ b/src/renderer/components/CreateProjectWizard/ProjectSettings.jsx
@@ -36,6 +36,7 @@ class ProjectSettings extends React.PureComponent {
         <div className="row">
           <div className="col-md-12">
             <div className="form-group form-row" key="installType">
+              <h3 className="text-center w-100 mb-3">Create a new project</h3>
               <div className="btn-group w-100" id="installType">
                 <button
                   className={`btn btn-outline-secondary btn-lg ${


### PR DESCRIPTION
## The Problem/Issue/Bug:
Need to create the v0.5.0-alpha release.

## How this PR Solves The Problem:
Tag package,json with the v0.5.0-alpha and reduces builds by ONLY building mac OS now, unitl windows is supported.

## Manual Testing Instructions:
Should create a v0.5.0-alpha download.

## Related Issue Link(s):
#135 

